### PR TITLE
Use major version ref of `carlosperate/download-file-action`

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Download JSON schema for labels configuration file
         id: download-schema
-        uses: carlosperate/download-file-action@v1.0.3
+        uses: carlosperate/download-file-action@v1
         with:
           file-url: https://raw.githubusercontent.com/arduino/tooling-project-assets/main/workflow-templates/assets/sync-labels/arduino-tooling-gh-label-configuration-schema.json
           location: ${{ runner.temp }}/label-configuration-schema
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Download
-        uses: carlosperate/download-file-action@v1.0.3
+        uses: carlosperate/download-file-action@v1
         with:
           file-url: https://raw.githubusercontent.com/arduino/tooling-project-assets/main/workflow-templates/assets/sync-labels/${{ matrix.filename }}
 


### PR DESCRIPTION
The [`carlosperate/download-file-action` action](https://github.com/carlosperate/download-file-action) is used in the GitHub Actions workflows as a convenient way to download external resources.

A [major version ref](https://docs.github.com/en/actions/creating-actions/about-custom-actions#using-tags-for-release-management) has been added to that repository:
https://github.com/carlosperate/download-file-action/releases/tag/v1
It will always point to the latest release of the "1" major version series.
This means it is no longer necessary to do a full pin of the action version in use as before.

Use of the major version ref will cause the workflow to use a stable version of the action, while also benefiting from ongoing development to the action up until such time as a new major release of an action is made. At that time we would need to evaluate whether any changes to the workflow are required by the breaking change that triggered the major release before manually updating the major ref (e.g., uses: `carlosperate/download-file-action@v2`). I think this approach strikes the right balance between stability and maintainability for these workflows.